### PR TITLE
The receiver resets the session on TesterPresent

### DIFF
--- a/src/broadcast_receiver.cpp
+++ b/src/broadcast_receiver.cpp
@@ -32,7 +32,7 @@ void BroadcastReceiver::proceedReceivedData(const uint8_t* buffer,
     {
         case TESTER_PRESENT_REQ:
         {
-            if(buffer[1] == 0x80 && num_bytes >= 2)
+            if(buffer[0] == 0x3E && num_bytes >= 2)
             {
                 pUdsReceiver_->pSessionCtrl_->reset();
             }

--- a/src/broadcast_receiver.cpp
+++ b/src/broadcast_receiver.cpp
@@ -34,6 +34,7 @@ void BroadcastReceiver::proceedReceivedData(const uint8_t* buffer,
         {
             if(buffer[1] != 0x80)
             {
+               pUdsReceiver_->pSessionCtrl_->reset();
                 // -> beware of arrows ->
                 constexpr array<uint8_t, 1> tp = {TESTER_PRESENT_RES};
                 pUdsReceiver_->pIsoTpSender_->sendData(tp.data(), tp.size());

--- a/src/broadcast_receiver.cpp
+++ b/src/broadcast_receiver.cpp
@@ -32,14 +32,9 @@ void BroadcastReceiver::proceedReceivedData(const uint8_t* buffer,
     {
         case TESTER_PRESENT_REQ:
         {
-            if(buffer[0] == 0x3E && num_bytes >= 2)
-            {
-                pUdsReceiver_->pSessionCtrl_->reset();
-            }
-            else
+            if(buffer[1] != 0x80)
             {
                 // -> beware of arrows ->
-                pUdsReceiver_->pSessionCtrl_->reset();
                 constexpr array<uint8_t, 1> tp = {TESTER_PRESENT_RES};
                 pUdsReceiver_->pIsoTpSender_->sendData(tp.data(), tp.size());
             }

--- a/src/uds_receiver.cpp
+++ b/src/uds_receiver.cpp
@@ -91,6 +91,7 @@ UdsReceiver& UdsReceiver::operator=(UdsReceiver&& orig) noexcept
  */
 void UdsReceiver::proceedReceivedData(const uint8_t* buffer, const size_t num_bytes) noexcept
 {
+    pSessionCtrl_->reset(); //reset on any incoming uds request
     IsoTpReceiver::proceedReceivedData(buffer, num_bytes);
 
     const uint8_t udsServiceIdentifier = buffer[0];


### PR DESCRIPTION
Found a bug in this code. The session was reset rather from Supress-Pos-Response rather then Tester-Present.